### PR TITLE
仕様変更 plugin/trigger

### DIFF
--- a/docs/events/plugins.md
+++ b/docs/events/plugins.md
@@ -24,15 +24,17 @@
 部屋ID
 - instanceId: string
 プラグインインスタンスID
-- eventName: string
-イベント名
-- args: any[]
-引数
+- data: クライアント同士で用いるデータ
+    - event: string
+    イベント名
+    - args: any[]
+    引数
 ## server to client
-- event: string
-イベント名
-- args: any[]
-引数
+- data: クライアント同士で用いるデータ
+    - event: string
+    イベント名
+    - args: any[]
+    引数
 
 # `plugin/sync`
 ## client to server


### PR DESCRIPTION
クライアント同士だけで用いるデータを `data` に変更しました．
`event` と `args` が `data` の中に入っています．
大丈夫そうならお願いします．
```json
{
  "data": {
    "event": "string",
    "args": []
  }
}
```